### PR TITLE
confファイルでディレクティブが重複した場合の処理

### DIFF
--- a/configuration/default.conf
+++ b/configuration/default.conf
@@ -2,6 +2,7 @@ server{
 	listen 127.0.0.1:8080;
 	server_name localhost;
 	default_error_page error_page.html;
+
 	location / {
 		error_page 400 404 405 408 4XX;
 		error_page 500 503 5XX;
@@ -13,11 +14,24 @@ server{
 		chunked_transfer_encoding off;
 	}
 
+	location /cgi-bin/ {
+		error_page 400 404 405 408 4XX;
+		error_page 500 503 5XX;
+		client_max_body_size 1M;
+		root html;
+		index index.html;
+		autoindex off;
+		allow_methods GET POST DELETE;
+		chunked_transfer_encoding off;
+		cgi on;
+		cgi_extension .php .py;
+	}
 }
 
 server{
-	listen 127.0.0.1:80;
+	listen 127.0.0.1:8081;
 	server_name localhost;
+
 	location / {
 		error_page 400 404 405 408 4XX;
 		error_page 500 503 5XX;

--- a/configuration/default.conf
+++ b/configuration/default.conf
@@ -13,19 +13,6 @@ server{
 		allow_methods GET POST DELETE;
 		chunked_transfer_encoding off;
 	}
-
-	location /cgi-bin/ {
-		error_page 400 404 405 408 4XX;
-		error_page 500 503 5XX;
-		client_max_body_size 1M;
-		root html;
-		index index.html;
-		autoindex off;
-		allow_methods GET POST DELETE;
-		chunked_transfer_encoding off;
-		cgi on;
-		cgi_extension .php .py;
-	}
 }
 
 server{

--- a/srcs/configuration/location_directive.cpp
+++ b/srcs/configuration/location_directive.cpp
@@ -65,6 +65,7 @@ int LocationDirective::parseLocationDirective(std::vector<std::string>& tokens) 
 				return -1;
 			}
 		} else if (tokens.front() == "allow_methods") {
+			allow_methods_.clear();
 			args = ParserUtils::extractTokensUntilSemicolon(tokens);
 			if (parseAllowMethodsDirective(args) == -1) {
 				return -1;
@@ -96,7 +97,6 @@ int LocationDirective::parseErrorPageDirective(std::vector<std::string>& tokens)
 				return -1;
 			}
 		}
-		std::cout << "test: " << tokens[i] << " : " << tokens[tokens.size() - 1] << std::endl;
 		error_pages_[tokens[i]] = tokens[tokens.size() - 1];
 	}
 	return 0;

--- a/srcs/configuration/location_directive.cpp
+++ b/srcs/configuration/location_directive.cpp
@@ -15,7 +15,7 @@ LocationDirective::LocationDirective() {
 LocationDirective::~LocationDirective() {}
 
 LocationDirective::LocationDirective(const LocationDirective& other)
-	: error_page_(other.error_page_)
+	: error_pages_(other.error_pages_)
 	, allow_methods_(other.allow_methods_)
 	, client_max_body_size_(other.client_max_body_size_)
 	, root_(other.root_)
@@ -25,7 +25,7 @@ LocationDirective::LocationDirective(const LocationDirective& other)
 
 LocationDirective& LocationDirective::operator=(const LocationDirective& other) {
 	if (this != &other) {
-		error_page_ = other.error_page_;
+		error_pages_ = other.error_pages_;
 		allow_methods_ = other.allow_methods_;
 		client_max_body_size_ = other.client_max_body_size_;
 		root_ = other.root_;
@@ -96,7 +96,8 @@ int LocationDirective::parseErrorPageDirective(std::vector<std::string>& tokens)
 				return -1;
 			}
 		}
-		error_page_.push_back(tokens[i]);
+		std::cout << "test: " << tokens[i] << " : " << tokens[tokens.size() - 1] << std::endl;
+		error_pages_[tokens[i]] = tokens[tokens.size() - 1];
 	}
 	return 0;
 }
@@ -184,8 +185,8 @@ int LocationDirective::parseChunkedTransferEncodingDirective(std::vector<std::st
 	return 0;
 }
 
-std::vector<std::string> LocationDirective::getErrorPage() const {
-	return error_page_;
+std::map<std::string, std::string> LocationDirective::getErrorPages() const {
+	return error_pages_;
 }
 
 std::vector<std::string> LocationDirective::getAllowMethods() const {
@@ -213,17 +214,19 @@ std::string LocationDirective::getChunkedTransferEncoding() const {
 }
 
 std::ostream& operator<<(std::ostream& out, const LocationDirective& location_directive) {
-	std::vector<std::string> error_pages = location_directive.getErrorPage();
+	std::map<std::string, std::string> error_pages = location_directive.getErrorPages();
 	out << "ErrorPages: " << std::endl;
-	for (size_t i = 0; i < error_pages.size(); ++i) {
-		out << error_pages[i] << std::endl;
+	for (std::map<std::string, std::string>::iterator it = error_pages.begin(); it != error_pages.end(); ++it) {
+		out << it->first << ":" << it->second << ", ";
 	}
+	std::cout << std::endl;
 
 	std::vector<std::string> allow_methods = location_directive.getAllowMethods();
 	out << "HTTPMethods: " << std::endl;
 	for (size_t i = 0; i < allow_methods.size(); ++i) {
-		out << allow_methods[i] << std::endl;
+		out << allow_methods[i] << ", ";
 	}
+	std::cout << std::endl;
 
 	out << "GetClientMaxBodySize: " << location_directive.getClientMaxBodySize() << std::endl;
 	out << "Root: " << location_directive.getRoot() << std::endl;

--- a/srcs/configuration/location_directive.cpp
+++ b/srcs/configuration/location_directive.cpp
@@ -216,7 +216,9 @@ std::string LocationDirective::getChunkedTransferEncoding() const {
 std::ostream& operator<<(std::ostream& out, const LocationDirective& location_directive) {
 	std::map<std::string, std::string> error_pages = location_directive.getErrorPages();
 	out << "ErrorPages: " << std::endl;
-	for (std::map<std::string, std::string>::iterator it = error_pages.begin(); it != error_pages.end(); ++it) {
+	for (std::map<std::string, std::string>::iterator it = error_pages.begin();
+		 it != error_pages.end();
+		 ++it) {
 		out << it->first << ":" << it->second << ", ";
 	}
 	std::cout << std::endl;

--- a/srcs/configuration/location_directive.hpp
+++ b/srcs/configuration/location_directive.hpp
@@ -9,7 +9,7 @@
 
 class LocationDirective {
 private:
-	std::vector<std::string> error_page_;
+	std::map<std::string, std::string> error_pages_;
 	std::vector<std::string> allow_methods_;
 	std::string client_max_body_size_;
 	std::string root_;
@@ -32,7 +32,7 @@ public:
 	LocationDirective& operator=(const LocationDirective& other);
 
 	int parseLocationDirective(std::vector<std::string>& tokens);
-	std::vector<std::string> getErrorPage() const;
+	std::map<std::string, std::string> getErrorPages() const;
 	std::vector<std::string> getAllowMethods() const;
 	std::string getClientMaxBodySize() const;
 	std::string getRoot() const;

--- a/srcs/configuration/server_directive.cpp
+++ b/srcs/configuration/server_directive.cpp
@@ -176,9 +176,7 @@ std::ostream& operator<<(std::ostream& out, const ServerDirective& server_direct
 
 	std::map<std::string, LocationDirective> locations = server_directive.getLocations();
 	size_t i = 0;
-	for (std::map<std::string, LocationDirective>::iterator it = locations.begin();
-		 it != locations.end();
-		 ++it) {
+	for (std::map<std::string, LocationDirective>::iterator it = locations.begin(); it != locations.end(); ++it) {
 		out << "===== location" << i << " =====" << std::endl;
 		out << "LocationPath: " << it->first << std::endl;
 		out << it->second << std::endl;

--- a/srcs/configuration/server_directive.cpp
+++ b/srcs/configuration/server_directive.cpp
@@ -176,7 +176,9 @@ std::ostream& operator<<(std::ostream& out, const ServerDirective& server_direct
 
 	std::map<std::string, LocationDirective> locations = server_directive.getLocations();
 	size_t i = 0;
-	for (std::map<std::string, LocationDirective>::iterator it = locations.begin(); it != locations.end(); ++it) {
+	for (std::map<std::string, LocationDirective>::iterator it = locations.begin();
+		 it != locations.end();
+		 ++it) {
 		out << "===== location" << i << " =====" << std::endl;
 		out << "LocationPath: " << it->first << std::endl;
 		out << it->second << std::endl;

--- a/srcs/main.cpp
+++ b/srcs/main.cpp
@@ -14,12 +14,13 @@ int main(int argc, char** argv) {
 			return 1;
 	}
 
+	std::cout << configuration << std::endl;
+
 	server::IoMultiplexing server(configuration);
 	if (server.initialize() < 0) {
 		std::cerr << "Server initialize failed" << std::endl;
 		return -1;
 	}
 	server.runServer();
-	// start();
 	return 0;
 }


### PR DESCRIPTION
### やること
- confファイルでディレクティブが重複した場合の処理を実装
- confファイルのwikiにMultiplicityという項目を追加
  - https://github.com/libknt/webserv/wiki/.conf
- Multiplicity: Multipleになっているディレクティブの動作
  - ディレクティブが複数入った場合、全て保存する
- Multiplicity: Singleになっているディレクティブの動作
  - 後から入ってきた設定に上書きされる
