### PR TITLE
エラーメッセージの追加、拡張子が.confではない場合にエラーにする

### DIFF
--- a/srcs/configuration/configuration.cpp
+++ b/srcs/configuration/configuration.cpp
@@ -19,7 +19,7 @@ int Configuration::init(const std::string& path) {
 	std::vector<std::string> tokens;
 	std::ifstream conf_file(path.c_str());
 	if (conf_file.fail()) {
-		std::cerr << "Open conf file failed" << std::endl;
+		std::cerr << "File Error: Open conf file failed" << std::endl;
 		return -1;
 	}
 	tokens = tokenize_file_content(conf_file);
@@ -82,7 +82,7 @@ int Configuration::parseConfiguration(std::vector<std::string>& tokens) {
 			}
 			servers_.push_back(server_directive);
 		} else {
-			std::cerr << "Configration file error: invalid main directive." << std::endl;
+			std::cerr << "Parse Error: Invalid main directive" << std::endl;
 			return -1;
 		}
 	}

--- a/srcs/configuration/configuration.cpp
+++ b/srcs/configuration/configuration.cpp
@@ -16,12 +16,17 @@ Configuration& Configuration::operator=(const Configuration& other) {
 
 // TODO: 関数切り分けか命名変更
 int Configuration::init(const std::string& path) {
-	std::vector<std::string> tokens;
+	if (path.size() < 5 || path.find(".conf", path.size() - 5) == std::string::npos) {
+		std::cerr << "File Error: The path contains an incorrect file extension" << std::endl;
+	}
+
 	std::ifstream conf_file(path.c_str());
 	if (conf_file.fail()) {
 		std::cerr << "File Error: Open conf file failed" << std::endl;
 		return -1;
 	}
+
+	std::vector<std::string> tokens;
 	tokens = tokenize_file_content(conf_file);
 	if (parseConfiguration(tokens) == -1) {
 		return -1;

--- a/srcs/configuration/server_directive.cpp
+++ b/srcs/configuration/server_directive.cpp
@@ -142,6 +142,7 @@ int ServerDirective::parseServerNameDirective(std::vector<std::string>& tokens) 
 
 int ServerDirective::parseDefaultErrorPageDirective(std::vector<std::string>& tokens) {
 	if (tokens.size() != 1) {
+		std::cerr << "Parse Error: parseDefaultErrorPageDirective" << std::endl;
 		return -1;
 	}
 	default_error_page_ = tokens.front();

--- a/srcs/configuration/server_directive.cpp
+++ b/srcs/configuration/server_directive.cpp
@@ -111,7 +111,7 @@ bool ServerDirective::isValidIPv4(const std::string& ip_address) const {
 		return false;
 	}
 	return dot1 == '.' && dot2 == '.' && dot3 == '.' && isValidIPSegment(segment1) &&
-		isValidIPSegment(segment2) && isValidIPSegment(segment3) && isValidIPSegment(segment4);
+		   isValidIPSegment(segment2) && isValidIPSegment(segment3) && isValidIPSegment(segment4);
 }
 
 bool ServerDirective::isValidIPSegment(int num) const {

--- a/srcs/configuration/server_directive.cpp
+++ b/srcs/configuration/server_directive.cpp
@@ -76,14 +76,14 @@ int ServerDirective::parseServerDirective(std::vector<std::string>& tokens) {
 
 int ServerDirective::parseListenDirective(std::vector<std::string>& tokens) {
 	if (tokens.empty()) {
-		std::cerr << "Parse Error: parseListenDirective1" << std::endl;
+		std::cerr << "Parse Error: parseListenDirective" << std::endl;
 		return -1;
 	}
 
 	std::string token = tokens.front();
 	size_t found = token.find(":");
 	if (found == std::string::npos || found == 0 || found == token.size() - 1) {
-		std::cerr << "Parse Error: parseListenDirective2" << std::endl;
+		std::cerr << "Parse Error: parseListenDirective" << std::endl;
 		return -1;
 	}
 
@@ -95,7 +95,7 @@ int ServerDirective::parseListenDirective(std::vector<std::string>& tokens) {
 
 	port_ = token.substr(found + 1);
 	if (!isValidPort(port_)) {
-		std::cerr << "Invalid port." << std::endl;
+		std::cerr << "Parse Error:Invalid port" << std::endl;
 		return -1;
 	}
 	return 0;
@@ -111,7 +111,7 @@ bool ServerDirective::isValidIPv4(const std::string& ip_address) const {
 		return false;
 	}
 	return dot1 == '.' && dot2 == '.' && dot3 == '.' && isValidIPSegment(segment1) &&
-		   isValidIPSegment(segment2) && isValidIPSegment(segment3) && isValidIPSegment(segment4);
+		isValidIPSegment(segment2) && isValidIPSegment(segment3) && isValidIPSegment(segment4);
 }
 
 bool ServerDirective::isValidIPSegment(int num) const {


### PR DESCRIPTION
### やったこと
- 抜けていたエラーメッセージの追加
- .confではない拡張子の場合エラーを出力する