### PR TITLE
feat: HttpRequestのオペレータにclient_addrとserver_addを追加

### DIFF
--- a/srcs/server/request/http_request.cpp
+++ b/srcs/server/request/http_request.cpp
@@ -299,13 +299,13 @@ int HttpRequest::setHeaderValue(std::string const& key, std::string const& value
 }
 
 std::ostream& operator<<(std::ostream& out, const HttpRequest& request) {
-	
+
 	sockaddr_in client_address = request.getClientAddress();
 	sockaddr_in server_address = request.getServerAddress();
 	char* client_ip = inet_ntoa(client_address.sin_addr);
-    unsigned short client_port = ntohs(client_address.sin_port);
+	unsigned short client_port = ntohs(client_address.sin_port);
 	char* server_ip = inet_ntoa(server_address.sin_addr);
-    unsigned short server_port = ntohs(server_address.sin_port);
+	unsigned short server_port = ntohs(server_address.sin_port);
 	out << "client ip: " << client_ip << std::endl;
 	out << "client port: " << client_port << std::endl;
 	out << "server ip: " << server_ip << std::endl;

--- a/srcs/server/request/http_request.cpp
+++ b/srcs/server/request/http_request.cpp
@@ -299,6 +299,17 @@ int HttpRequest::setHeaderValue(std::string const& key, std::string const& value
 }
 
 std::ostream& operator<<(std::ostream& out, const HttpRequest& request) {
+	
+	sockaddr_in client_address = request.getClientAddress();
+	sockaddr_in server_address = request.getServerAddress();
+	char* client_ip = inet_ntoa(client_address.sin_addr);
+    unsigned short client_port = ntohs(client_address.sin_port);
+	char* server_ip = inet_ntoa(server_address.sin_addr);
+    unsigned short server_port = ntohs(server_address.sin_port);
+	out << "client ip: " << client_ip << std::endl;
+	out << "client port: " << client_port << std::endl;
+	out << "server ip: " << server_ip << std::endl;
+	out << "server port: " << server_port << std::endl;
 	out << "method: " << request.getMethod() << std::endl;
 	out << "status: " << request.getStatus() << std::endl;
 	out << "version: " << request.getVersion() << std::endl;

--- a/srcs/server/request/http_request.hpp
+++ b/srcs/server/request/http_request.hpp
@@ -1,10 +1,10 @@
 #ifndef HTTP_REQUEST_HPP
 #define HTTP_REQUEST_HPP
+#include <arpa/inet.h>
 #include <iostream>
 #include <map>
 #include <netinet/in.h>
 #include <string>
-#include <arpa/inet.h>
 
 namespace server {
 namespace http_request_status {

--- a/srcs/server/request/http_request.hpp
+++ b/srcs/server/request/http_request.hpp
@@ -4,6 +4,7 @@
 #include <map>
 #include <netinet/in.h>
 #include <string>
+#include <arpa/inet.h>
 
 namespace server {
 namespace http_request_status {


### PR DESCRIPTION
```

int IoMultiplexing::accept(int listen_sd) {

	int new_sd;
	std::cout << "  Listening socket is readable" << std::endl;
	do {
		sockaddr_in client_address;
		socklen_t addr_len = sizeof(client_address);
		memset(&client_address, 0, sizeof(client_address));
		new_sd = ::accept(listen_sd, (sockaddr*)&client_address, &addr_len);
		if (new_sd < 0) {
			if (errno != EWOULDBLOCK) {
				std::cerr << "accept() failed: " << strerror(errno) << std::endl;
				return -1;
			}
			break;
		}
		sockaddr_in server_address;
		addr_len = sizeof(server_address);

		if (getsockname(new_sd, (struct sockaddr*)&server_address, &addr_len) == -1) {
			std::cerr << strerror(errno) << std::endl;
			return -1;
		}

		http_request_parse_.addAcceptClientInfo(new_sd, client_address, server_address);

		std::cout << "  New incoming connection -  " << new_sd << std::endl;
		FD_SET(new_sd, &master_read_fds_);
		if (new_sd > max_sd_)
			max_sd_ = new_sd;
                //   ※ここをついか
		{
			HttpRequest & request = http_request_parse_.getHttpRequest(new_sd);
			std::cout << request << std::endl;
		}
	} while (new_sd != -1);
	return 0;
}
```

このように使用するとserverとclientの使用しているportとaddressが見れるよ！