### PR TITLE
confファイルのlocationが重複した場合、最初の一つだけを入れる

### DIFF
--- a/srcs/configuration/server_directive.cpp
+++ b/srcs/configuration/server_directive.cpp
@@ -52,7 +52,7 @@ int ServerDirective::parseServerDirective(std::vector<std::string>& tokens) {
 			}
 		} else if (tokens.front() == "location") {
 			tokens.erase(tokens.begin());
-			std::string location_path = parseLocationPath(tokens);
+			location_path = parseLocationPath(tokens);
 			if (location_path.empty()) {
 				return -1;
 			}
@@ -60,7 +60,9 @@ int ServerDirective::parseServerDirective(std::vector<std::string>& tokens) {
 			if (location_directive.parseLocationDirective(location_tokens) == -1) {
 				return -1;
 			}
-			locations_[location_path] = location_directive;
+			if (locations_.find(location_path) == locations_.end()) {
+				locations_[location_path] = location_directive;
+			}
 		} else {
 			std::cerr << "Parse Error: serverDirective" << std::endl;
 			return -1;


### PR DESCRIPTION
### やったこと
- confファイルのlocationが重複した場合、最初の一つだけを入れるよう変更

### 動作確認
- default.conf に 重複するlocationを入れて最初の設定が残っているか確認する