### PR TITLE
location / がなかった場合にデフォルトの設定で / を入れるよう変更

### DIFF
--- a/srcs/configuration/server_directive.cpp
+++ b/srcs/configuration/server_directive.cpp
@@ -69,6 +69,9 @@ int ServerDirective::parseServerDirective(std::vector<std::string>& tokens) {
 		}
 		args.clear();
 	}
+	if (locations_.find("/") == locations_.end()) {
+		locations_["/"] = LocationDirective();
+	}
 	return 0;
 }
 

--- a/srcs/main.cpp
+++ b/srcs/main.cpp
@@ -22,8 +22,6 @@ int main(int argc, char** argv) {
 			return 1;
 	}
 
-	std::cout << configuration << std::endl;
-
 	server::ServerManager server(configuration);
 	if (server.runServer() != -1) {
 		std::cerr << "runServer() failed" << std::endl;

--- a/srcs/main.cpp
+++ b/srcs/main.cpp
@@ -22,6 +22,8 @@ int main(int argc, char** argv) {
 			return 1;
 	}
 
+	std::cout << configuration << std::endl;
+
 	server::ServerManager server(configuration);
 	if (server.runServer() != -1) {
 		std::cerr << "runServer() failed" << std::endl;


### PR DESCRIPTION
###  対応背景
- locationが一致しなかった場合にどのような設定でresponseを作成するか定めるため
- locationがない場合にエラーにしないため

### やったこと
- location / がなかった場合にserverディレクティブにデフォルト設定で location / を追加する

### 確認方法
- default.confにlocation / がないサーバーを作り、実行する