### PR TITLE
http-requestのstatus-codeをhttp_status_codeに統一

### DIFF
--- a/srcs/server/request/http_request.cpp
+++ b/srcs/server/request/http_request.cpp
@@ -50,8 +50,8 @@ http_request_status::HTTP_REQUEST_STATUS const& HttpRequest::getStatus() const {
 	return (status_);
 }
 
-http_error_status::HTTP_ERROR_STATUS const& HttpRequest::getErrorStatus() const {
-	return (error_status_);
+http_status_code::STATUS_CODE const& HttpRequest::getHttpStatusCode() const {
+	return (status_code_);
 }
 
 std::string const HttpRequest::getMethod() const {
@@ -196,8 +196,8 @@ void HttpRequest::setStatus(http_request_status::HTTP_REQUEST_STATUS const& stat
 	status_ = status;
 }
 
-void HttpRequest::setErrorStatus(http_error_status::HTTP_ERROR_STATUS const& error_status) {
-	error_status_ = error_status;
+void HttpRequest::setHttpStatusCode(http_status_code::STATUS_CODE const& status_code) {
+	status_code_ = status_code;
 }
 
 int HttpRequest::setMethod(std::string const& method) {

--- a/srcs/server/request/http_request.hpp
+++ b/srcs/server/request/http_request.hpp
@@ -46,7 +46,6 @@ enum HTTP_VERSION {
 };
 }
 
-
 namespace http_body_message_type {
 enum HTTP_BODY_MESSAGE_TYPE {
 	CONTENT_LENGTH,

--- a/srcs/server/request/http_request.hpp
+++ b/srcs/server/request/http_request.hpp
@@ -1,5 +1,6 @@
 #ifndef HTTP_REQUEST_HPP
 #define HTTP_REQUEST_HPP
+#include "webserv.hpp"
 #include <arpa/inet.h>
 #include <iostream>
 #include <map>
@@ -45,12 +46,6 @@ enum HTTP_VERSION {
 };
 }
 
-namespace http_error_status {
-enum HTTP_ERROR_STATUS {
-	BAD_REQUEST = 400,
-	UNDEFINED,
-};
-}
 
 namespace http_body_message_type {
 enum HTTP_BODY_MESSAGE_TYPE {
@@ -65,7 +60,7 @@ class HttpRequest {
 private:
 	std::string stream_line_;
 	http_request_status::HTTP_REQUEST_STATUS status_;
-	http_error_status::HTTP_ERROR_STATUS error_status_;
+	http_status_code::STATUS_CODE status_code_;
 	http_method::HTTP_METHOD method_;
 	std::string uri_;
 	http_version::HTTP_VERSION version_;
@@ -89,7 +84,7 @@ public:
 	void setStreamLine(std::string const& stream_line);
 	void eraseStreamLine(std::string::size_type position, std::string::size_type n);
 	void setStatus(http_request_status::HTTP_REQUEST_STATUS const& status);
-	void setErrorStatus(http_error_status::HTTP_ERROR_STATUS const& error_status);
+	void setHttpStatusCode(http_status_code::STATUS_CODE const& status_code);
 	int setMethod(std::string const& method);
 	int setUri(std::string const& uri);
 	int setVersion(std::string const& version);
@@ -103,7 +98,7 @@ public:
 
 	std::string const& getStreamLine() const;
 	http_request_status::HTTP_REQUEST_STATUS const& getStatus() const;
-	http_error_status::HTTP_ERROR_STATUS const& getErrorStatus() const;
+	http_status_code::STATUS_CODE const& getHttpStatusCode() const;
 	std::string const getMethod() const;
 	http_method::HTTP_METHOD getHttpMethod() const;
 	std::string const getVersion() const;

--- a/srcs/server/request/http_request_parser.cpp
+++ b/srcs/server/request/http_request_parser.cpp
@@ -126,7 +126,7 @@ int HttpRequestParser::parseBody(HttpRequest& request, std::string const& line) 
 			return (parseContentLengthBody(request, line));
 		default:
 			request.setStatus(http_request_status::ERROR);
-			request.setErrorStatus(http_error_status::BAD_REQUEST);
+			request.setHttpStatusCode(http_status_code::BAD_REQUEST);
 			return (-1);
 	}
 }
@@ -137,7 +137,7 @@ int HttpRequestParser::parseContentLengthBody(HttpRequest& request, std::string 
 		request.setStatus(http_request_status::FINISHED);
 	else if (request.getContentLength() < request.getBodySize()) {
 		request.setStatus(http_request_status::ERROR);
-		request.setErrorStatus(http_error_status::BAD_REQUEST);
+		request.setHttpStatusCode(http_status_code::BAD_REQUEST);
 		return (-1);
 	}
 	return (0);
@@ -153,7 +153,7 @@ int HttpRequestParser::parseChunkedBody(HttpRequest& request, std::string const&
 	} else {
 		if (request.getChunkedSize() != line.size()) {
 			request.setStatus(http_request_status::ERROR);
-			request.setErrorStatus(http_error_status::BAD_REQUEST);
+			request.setHttpStatusCode(http_status_code::BAD_REQUEST);
 			return (-1);
 		}
 		request.appendBody(line);
@@ -180,7 +180,7 @@ int HttpRequestParser::checkHeaderValue(HttpRequest& request) {
 		request.setStatus(http_request_status::BODY);
 	} else {
 		request.setStatus(http_request_status::ERROR);
-		request.setErrorStatus(http_error_status::BAD_REQUEST);
+		request.setHttpStatusCode(http_status_code::BAD_REQUEST);
 		return (-1);
 	}
 	return (0);


### PR DESCRIPTION
http_error_statusはよくみたらhttp_status_codeの一部だったので削除しました。