### PR TITLE
cgi_extensionを .+ 英字 or 数字 ならなんでもOKにする

### DIFF
--- a/configuration/sokuno.conf
+++ b/configuration/sokuno.conf
@@ -7,7 +7,7 @@ server {
 		error_page 400 404 405 408 4XX;
 		error_page 500 503 5XX;
 		client_max_body_size 1M;
-		root html;
+		root /Users/soooku/42/webserv;
 		index index.html;
 		autoindex on;
 		allow_methods GET POST DELETE;
@@ -19,7 +19,7 @@ server {
 		error_page 400 404 405 408 4XX;
 		error_page 500 503 5XX;
 		client_max_body_size 1M;
-		root html;
+		root /Users/soooku/42/webserv;
 		index index.html;
 		autoindex on;
 		allow_methods GET POST DELETE;
@@ -31,13 +31,13 @@ server {
 		error_page 400 404 405 408 4XX;
 		error_page 500 503 5XX;
 		client_max_body_size 1M;
-		root html;
+		root /Users/soooku/42/webserv;
 		index index.html;
 		autoindex on;
 		allow_methods GET POST DELETE;
 		chunked_transfer_encoding off;
 		cgi on;
-		cgi_extensions .py .php;
+		cgi_extensions .php;
 	}
 
 	location /test.py {
@@ -45,7 +45,7 @@ server {
 		error_page 400 404 405 408 4XX;
 		error_page 500 503 5XX;
 		client_max_body_size 1M;
-		root html;
+		root /Users/soooku/42/webserv;
 		index index.html;
 		autoindex on;
 		allow_methods GET POST DELETE;
@@ -65,7 +65,7 @@ server {
 		error_page 400 404 405 408 4XX;
 		error_page 500 503 5XX;
 		client_max_body_size 1M;
-		root html;
+		root /Users/soooku/42/webserv;
 		index index.html;
 		autoindex off;
 		allow_methods GET POST DELETE;

--- a/srcs/configuration/location_directive.cpp
+++ b/srcs/configuration/location_directive.cpp
@@ -298,10 +298,21 @@ int LocationDirective::parseCgiExtensionsDirective(std::vector<std::string>& tok
 		return -1;
 	}
 	for (size_t i = 0; i < tokens.size(); ++i) {
-		if (tokens[i] != ".cgi" && tokens[i] != ".pl" && tokens[i] != ".py" &&
-			tokens[i] != ".php" && tokens[i] != ".sh") {
+		if (tokens[i].size() < 2) {
 			std::cerr << "Parse Error: parseCgiExtensionsDirective" << std::endl;
 			return -1;
+		}
+		for (size_t j = 0; j < tokens[i].size(); ++j) {
+			if (j == 0) {
+				if (tokens[i][j] != '.') {
+					std::cerr << "Parse Error: parseCgiExtensionsDirective" << std::endl;
+					return -1;
+				}
+			} else if (!std::isalnum(tokens[i][j])) {
+				std::cerr << "Parse Error: parseCgiExtensionsDirective" << std::endl;
+				std::cerr << tokens[i][j] << std::endl;
+				return -1;
+			}
 		}
 		cgi_extensions_.insert(tokens[i]);
 	}


### PR DESCRIPTION
### Issue 
close #117 

### やったこと
- cgi_extensionを .+ 英字 or 数字 ならなんでもOKにする
  - 以前は.pyなど指定したものだけだった

### テスト方法
- .confファイルのcgi_extensionsの部分に色々入れてテスト
#### OKケース例
- .py .123 .a1b
#### NGケース例
- . ..test .a~ 