### PR TITLE
allow_methodが機能していない問題を修正

### DIFF
--- a/configuration/default.conf
+++ b/configuration/default.conf
@@ -64,7 +64,7 @@ server {
 		root html;
 		index index.html;
 		autoindex off;
-		allow_methods POST;
+		allow_methods GET POST DELETE;
 		chunked_transfer_encoding off;
 	}
 }

--- a/configuration/default.conf
+++ b/configuration/default.conf
@@ -61,10 +61,10 @@ server {
 		default_error_page error_page.html;
 		error_page 400 404 405 408 4XX;
 		error_page 500 503 5XX;
-		root html;
+		root /Users/sokuno/sgoinfre/webserv/templates;
 		index index.html;
 		autoindex off;
-		allow_methods GET POST DELETE;
+		allow_methods POST;
 		chunked_transfer_encoding off;
 	}
 }

--- a/configuration/default.conf
+++ b/configuration/default.conf
@@ -1,12 +1,12 @@
 server {
 	listen 127.0.0.1:8080;
 	server_name localhost;
+	client_max_body_size 1M;
 
 	location / {
 		default_error_page error_page.html;
 		error_page 400 404 405 408 4XX;
 		error_page 500 503 5XX;
-		client_max_body_size 1M;
 		root html;
 		index index.html;
 		autoindex on;
@@ -18,7 +18,6 @@ server {
 		default_error_page error_page.html;
 		error_page 400 404 405 408 4XX;
 		error_page 500 503 5XX;
-		client_max_body_size 1M;
 		root html;
 		index index.html;
 		autoindex on;
@@ -30,7 +29,6 @@ server {
 		default_error_page error_page.html;
 		error_page 400 404 405 408 4XX;
 		error_page 500 503 5XX;
-		client_max_body_size 1M;
 		root html;
 		index index.html;
 		autoindex on;
@@ -44,7 +42,6 @@ server {
 		default_error_page error_page.html;
 		error_page 400 404 405 408 4XX;
 		error_page 500 503 5XX;
-		client_max_body_size 1M;
 		root html;
 		index index.html;
 		autoindex on;
@@ -64,7 +61,6 @@ server {
 		default_error_page error_page.html;
 		error_page 400 404 405 408 4XX;
 		error_page 500 503 5XX;
-		client_max_body_size 1M;
 		root html;
 		index index.html;
 		autoindex off;

--- a/configuration/default.conf
+++ b/configuration/default.conf
@@ -61,7 +61,7 @@ server {
 		default_error_page error_page.html;
 		error_page 400 404 405 408 4XX;
 		error_page 500 503 5XX;
-		root /Users/sokuno/sgoinfre/webserv/templates;
+		root html;
 		index index.html;
 		autoindex off;
 		allow_methods POST;

--- a/srcs/configuration/location_directive.cpp
+++ b/srcs/configuration/location_directive.cpp
@@ -176,6 +176,7 @@ int LocationDirective::parseAutoindexDirective(std::vector<std::string>& tokens)
 }
 
 int LocationDirective::parseAllowMethodsDirective(std::vector<std::string>& tokens) {
+	allow_methods_.clear();
 	if (tokens.empty()) {
 		std::cerr << "Parse Error: parseAllowMethodsDirective" << std::endl;
 		return -1;

--- a/srcs/server/handle_request/handle_request.cpp
+++ b/srcs/server/handle_request/handle_request.cpp
@@ -11,8 +11,6 @@ void handleRequest(ClientSession& client_session) {
 	const LocationDirective& location_directive =
 		server_directive.findLocation(request.getUriPath());
 
-	// TODO: redirectURLのみの指定でもいいかも
-	// TODO: configurationを綺麗にするPRでStatusCode周りを変更する
 	const std::vector<std::string> return_directive = location_directive.getReturn();
 	if (!return_directive.empty()) {
 		response.setStatusCode(http_status_code::FOUND);

--- a/srcs/server/request/http_request.cpp
+++ b/srcs/server/request/http_request.cpp
@@ -209,6 +209,7 @@ int HttpRequest::setMethod(std::string const& method) {
 		method_ = http_method::DELETE;
 	else {
 		setStatus(http_request_status::ERROR);
+		setHttpStatusCode(http_status_code::METHOD_NOT_ALLOWED);
 		return (-1);
 	}
 	return (0);


### PR DESCRIPTION
### Issue
close #127 close #128 

### 修正前の問題点
- GETのみallow_methodに書いていなくても使えてしまう
- GET, POST, DELETE以外のリクエストを送った場合UNKNOWNが返ってきてしまう

### やったこと
- 上記二つの問題を修正

### 動作確認
- allow_methodにGETを記述せずにGETリクエストを送り、405が返ってくることを確認する
e.g. `curl -X GET localhost:8081/`
- GET, POST, DELETE以外のリクエストを送信し、405が返ってくることを確認する
e.g. `curl -X UNDEFINED lcoalhost:8081/`