### PR TITLE
returnが機能していない問題を修正

### DIFF
--- a/configuration/default.conf
+++ b/configuration/default.conf
@@ -1,12 +1,12 @@
 server {
 	listen 127.0.0.1:8080;
 	server_name localhost;
+	client_max_body_size 1M;
 
 	location / {
 		default_error_page error_page.html;
 		error_page 400 404 405 408 4XX;
 		error_page 500 503 5XX;
-		client_max_body_size 1M;
 		root html;
 		index index.html;
 		autoindex on;
@@ -18,7 +18,6 @@ server {
 		default_error_page error_page.html;
 		error_page 400 404 405 408 4XX;
 		error_page 500 503 5XX;
-		client_max_body_size 1M;
 		root html;
 		index index.html;
 		autoindex on;
@@ -30,7 +29,6 @@ server {
 		default_error_page error_page.html;
 		error_page 400 404 405 408 4XX;
 		error_page 500 503 5XX;
-		client_max_body_size 1M;
 		root html;
 		index index.html;
 		autoindex on;
@@ -44,7 +42,6 @@ server {
 		default_error_page error_page.html;
 		error_page 400 404 405 408 4XX;
 		error_page 500 503 5XX;
-		client_max_body_size 1M;
 		root html;
 		index index.html;
 		autoindex on;
@@ -64,10 +61,10 @@ server {
 		default_error_page error_page.html;
 		error_page 400 404 405 408 4XX;
 		error_page 500 503 5XX;
-		client_max_body_size 1M;
-		root html;
+		root /Users/sokuno/sgoinfre/webserv/templates;
 		index index.html;
 		autoindex off;
+		return 301 http://example.com;
 		allow_methods GET POST DELETE;
 		chunked_transfer_encoding off;
 	}

--- a/configuration/default.conf
+++ b/configuration/default.conf
@@ -61,7 +61,7 @@ server {
 		default_error_page error_page.html;
 		error_page 400 404 405 408 4XX;
 		error_page 500 503 5XX;
-		root /Users/sokuno/sgoinfre/webserv/templates;
+		root html;
 		index index.html;
 		autoindex off;
 		return http://example.com;

--- a/configuration/default.conf
+++ b/configuration/default.conf
@@ -64,7 +64,7 @@ server {
 		root /Users/sokuno/sgoinfre/webserv/templates;
 		index index.html;
 		autoindex off;
-		return 301 http://example.com;
+		return http://example.com;
 		allow_methods GET POST DELETE;
 		chunked_transfer_encoding off;
 	}

--- a/srcs/configuration/location_directive.cpp
+++ b/srcs/configuration/location_directive.cpp
@@ -191,16 +191,11 @@ int LocationDirective::parseAllowMethodsDirective(std::vector<std::string>& toke
 }
 
 int LocationDirective::parseReturnDirective(std::vector<std::string>& tokens) {
-	if (tokens.size() != 2) {
+	if (tokens.size() != 1) {
 		std::cerr << "Parse Error: parseReturnDirective" << std::endl;
 		return -1;
 	}
-	if (!isStatusCode(tokens[0])) {
-		std::cerr << "Parse Error: parseReturnDirective" << std::endl;
-		return -1;
-	}
-	return_.push_back(tokens[0]);
-	return_.push_back(tokens[1]);
+	return_ = tokens[0];
 	return 0;
 }
 
@@ -299,7 +294,7 @@ bool LocationDirective::getAutoindex() const {
 	return autoindex_;
 }
 
-std::vector<std::string> const& LocationDirective::getReturn() const {
+std::string const& LocationDirective::getReturn() const {
 	return return_;
 }
 
@@ -365,9 +360,9 @@ std::ostream& operator<<(std::ostream& out, const LocationDirective& location_di
 	out << "Index: " << location_directive.getIndex() << std::endl;
 	out << "AutoIndex: " << location_directive.getAutoindex() << std::endl;
 
-	std::vector<std::string> return_directive = location_directive.getReturn();
+	std::string return_directive = location_directive.getReturn();
 	if (return_directive.size()) {
-		out << "Return: " << return_directive[0] << ":" << return_directive[1] << std::endl;
+		out << "Return: " << return_directive << std::endl;
 	}
 
 	out << "ChuckedTransferEncoding: " << location_directive.getChunkedTransferEncoding()

--- a/srcs/configuration/location_directive.hpp
+++ b/srcs/configuration/location_directive.hpp
@@ -21,14 +21,13 @@ private:
 	std::string root_;
 	std::string index_;
 	bool autoindex_;
-	std::vector<std::string> return_;
+	std::string return_;
 	bool chunked_transfer_encoding_;
 	bool cgi_;
 	std::set<std::string> cgi_extensions_;
 
 	int parseDefaultErrorPageDirective(std::vector<std::string>& tokens);
 	int parseErrorPageDirective(std::vector<std::string>& tokens);
-	int parseClientMaxBodySizeDirective(std::vector<std::string>& tokens);
 	int parseRootDirective(std::vector<std::string>& tokens);
 	int parseIndexDirective(std::vector<std::string>& tokens);
 	int parseAutoindexDirective(std::vector<std::string>& tokens);
@@ -55,7 +54,7 @@ public:
 	std::string getRoot() const;
 	std::string getIndex() const;
 	bool getAutoindex() const;
-	std::vector<std::string> const& getReturn() const;
+	std::string const& getReturn() const;
 	bool getChunkedTransferEncoding() const;
 	bool getCgi() const;
 	bool isCgiExtension(const std::string& extension) const;

--- a/srcs/server/handle_request/handle_request.cpp
+++ b/srcs/server/handle_request/handle_request.cpp
@@ -18,6 +18,7 @@ void handleRequest(ClientSession& client_session) {
 		response.setStatusCode(http_status_code::FOUND);
 		response.setHeaderValue("Location", return_directive.back());
 		response.concatenateComponents();
+		client_session.setStatus(SENDING_RESPONSE);
 		return;
 	}
 	std::cout << request << std::endl;

--- a/srcs/server/handle_request/handle_request.cpp
+++ b/srcs/server/handle_request/handle_request.cpp
@@ -11,12 +11,10 @@ void handleRequest(ClientSession& client_session) {
 	const LocationDirective& location_directive =
 		server_directive.findLocation(request.getUriPath());
 
-	// TODO: redirectURLのみの指定でもいいかも
-	// TODO: configurationを綺麗にするPRでStatusCode周りを変更する
-	const std::vector<std::string> return_directive = location_directive.getReturn();
+	const std::string return_directive = location_directive.getReturn();
 	if (!return_directive.empty()) {
 		response.setStatusCode(http_status_code::FOUND);
-		response.setHeaderValue("Location", return_directive.back());
+		response.setHeaderValue("Location", return_directive);
 		response.concatenateComponents();
 		client_session.setStatus(SENDING_RESPONSE);
 		return;


### PR DESCRIPTION
### Issue
close #132

### やったこと
- return_directiveの構文を変更
  - URL だけの指定にして、302をデフォルトで返すように変更しました。
  - それに合うようにwikiにも変更を加えました。
- returnが機能していない問題を修正
  - returnが設定されていた場合に、client_sessionのstatusがSENDING_RESPONSEに更新されていないようでした。
  (Waiting on select()! が大量に表示される問題も同じ原因だと考えらえれます)
 
### 動作確認
- localhost:8081にアクセスしてhttp://example.comにリダイレクトが行われるかを確認する
