### PR TITLE
binaryをPOST可能にしました。

### DIFF
--- a/srcs/server/request/http_request_parser.cpp
+++ b/srcs/server/request/http_request_parser.cpp
@@ -17,7 +17,7 @@ HttpRequestParser& HttpRequestParser::operator=(HttpRequestParser& other) {
 }
 
 void HttpRequestParser::parse(HttpRequest& request,
-	std::string const &recv_buffer,
+	std::string const& recv_buffer,
 	const size_t client_max_body_size) {
 
 	std::string::size_type index;

--- a/srcs/server/request/http_request_parser.cpp
+++ b/srcs/server/request/http_request_parser.cpp
@@ -17,13 +17,12 @@ HttpRequestParser& HttpRequestParser::operator=(HttpRequestParser& other) {
 }
 
 void HttpRequestParser::parse(HttpRequest& request,
-	const char* buf,
+	std::string const &recv_buffer,
 	const size_t client_max_body_size) {
 
-	std::string buffer(buf);
 	std::string::size_type index;
 
-	request.appendStreamLine(buffer);
+	request.appendStreamLine(recv_buffer);
 	if (client_max_body_size < request.getBody().size()) {
 		request.setHttpStatusCode(http_status_code::REQUEST_ENTITY_TOO_LARGE);
 		request.setStatus(http_request_status::ERROR);

--- a/srcs/server/request/http_request_parser.cpp
+++ b/srcs/server/request/http_request_parser.cpp
@@ -22,8 +22,7 @@ void HttpRequestParser::parse(HttpRequest& request,
 
 	std::string::size_type index;
 
-
-	request.appendStreamLine(buffer);
+	request.appendStreamLine(recv_buffer);
 	while ((index = request.getStreamLine().find("\r\n")) != std::string::npos) {
 		if (request.getStatus() == http_request_status::BODY &&
 			request.getBodyMessageType() == http_body_message_type::CONTENT_LENGTH)

--- a/srcs/server/request/http_request_parser.hpp
+++ b/srcs/server/request/http_request_parser.hpp
@@ -43,7 +43,9 @@ private:
 	static int checkHeaderValue(HttpRequest& request);
 
 public:
-	static void parse(HttpRequest& request, std::string const &recv_buffer, const size_t client_max_body_size);
+	static void parse(HttpRequest& request,
+		std::string const& recv_buffer,
+		const size_t client_max_body_size);
 };
 
 }

--- a/srcs/server/request/http_request_parser.hpp
+++ b/srcs/server/request/http_request_parser.hpp
@@ -43,7 +43,7 @@ private:
 	static int checkHeaderValue(HttpRequest& request);
 
 public:
-	static void parse(HttpRequest& request, const char* buf, const size_t client_max_body_size);
+	static void parse(HttpRequest& request, std::string const &recv_buffer, const size_t client_max_body_size);
 };
 
 }

--- a/srcs/server/server_manager.cpp
+++ b/srcs/server/server_manager.cpp
@@ -439,7 +439,7 @@ int ServerManager::receiveAndParseHttpRequest(ClientSession& client_session) {
 
 	HttpRequest& request = client_session.getRequest();
 	HttpRequestParser::parse(
-		request, recv_buffer, client_session.getServerDirective().getClientMaxBodySize());
+		request, std::string(recv_buffer, recv_result), client_session.getServerDirective().getClientMaxBodySize());
 	client_session.setSessionStatusFromHttpRequest();
 
 	return 0;

--- a/srcs/server/server_manager.cpp
+++ b/srcs/server/server_manager.cpp
@@ -438,8 +438,9 @@ int ServerManager::receiveAndParseHttpRequest(ClientSession& client_session) {
 	}
 
 	HttpRequest& request = client_session.getRequest();
-	HttpRequestParser::parse(
-		request, std::string(recv_buffer, recv_result), client_session.getServerDirective().getClientMaxBodySize());
+	HttpRequestParser::parse(request,
+		std::string(recv_buffer, recv_result),
+		client_session.getServerDirective().getClientMaxBodySize());
 	client_session.setSessionStatusFromHttpRequest();
 
 	return 0;

--- a/test/unit_test/request/srcs/main.cpp
+++ b/test/unit_test/request/srcs/main.cpp
@@ -27,7 +27,7 @@ int main(int argc, char* argv[]) {
 			int size = read(fd[i], buffer, BUFFER_SIZE - 1);
 			if (0 < size) {
 				is_all_read = false;
-				server::HttpRequestParser::parse(requests[i], buffer, 10000);
+				server::HttpRequestParser::parse(requests[i], std::string(buffer, size), 10000);
 			}
 		}
 	}

--- a/test/unit_test/request/srcs/request/http_request_parser.hpp
+++ b/test/unit_test/request/srcs/request/http_request_parser.hpp
@@ -43,7 +43,9 @@ private:
 	static int checkHeaderValue(HttpRequest& request);
 
 public:
-	static void parse(HttpRequest& request, const char* buf, const size_t client_max_body_size);
+	static void parse(HttpRequest& request,
+		std::string const& recv_buffer,
+		const size_t client_max_body_size);
 };
 
 }


### PR DESCRIPTION
#129 を修正したつもりです。
今まではバイナリにNULLが含まれてたらPOSTの処理が正常終了しませんでしたが、するようになりました。
recv_resultのサイズによって、std::stringの長さを判断をするようにしました。